### PR TITLE
Pe370 and solaris11 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :test do
   gem 'rspec-puppet', '~> 2.2'
   gem 'puppetlabs_spec_helper', '~> 0.10'
   gem 'metadata-json-lint', '~> 0.0'
-  gem 'rspec-puppet-facts', '~> 0.10'
+  gem 'rspec-puppet-facts', '~> 1.3'
 end
 
 group :system_tests do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,10 +23,7 @@ class puppet_agent (
 
   validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$','^sun4[uv]$','PowerPC_POWER'])
 
-  if versioncmp("${::clientversion}", '3.8.0') < 0 {
-    fail('upgrading requires Puppet 3.8')
-  }
-  elsif versioncmp("${::clientversion}", '4.0.0') >= 0 {
+  if versioncmp("${::clientversion}", '4.0.0') >= 0 {
     info('puppet_agent performs no actions on Puppet 4+')
   }
   else {

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -55,20 +55,19 @@ class puppet_agent::osfamily::solaris(
       # publisher entries will stop the installation process.
       # This must happen before removing any packages.
       exec { 'puppet_agent ensure pkg publishers are available':
-        # command   => "pkgrepo remove -s '${pkgrepo_dir}' '*'",
-        command   => "pkg refresh",
+        command   => 'pkg refresh',
         path      => '/bin:/usr/bin:/sbin:/usr/sbin',
         logoutput => 'on_failure',
         notify    => Exec['puppet_agent remove existing repo'],
       }
 
       exec { 'puppet_agent remove existing repo':
-        command   => "rm -rf '${pkgrepo_dir}'/'*'",
+        command   => "rm -rf '${pkgrepo_dir}'",
         path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-        onlyif    => "test -f ${pkgrepo_dir}/pkg5.repository",
+        onlyif    => "test -d ${pkgrepo_dir}",
         logoutput => 'on_failure',
         notify    => Exec['puppet_agent create repo'],
-        require   => Exec['puppet_agent ensure pkg publishers are available']
+        require   => Exec['puppet_agent ensure pkg publishers are available'],
       }
 
       exec { 'puppet_agent create repo':

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -51,12 +51,24 @@ class puppet_agent::osfamily::solaris(
 
       $pkgrepo_dir = '/etc/puppetlabs/installer/solaris.repo'
 
+      # Make sure the pkg publishers are all available.  Broken
+      # publisher entries will stop the installation process.
+      # This must happen before removing any packages.
+      exec { 'puppet_agent ensure pkg publishers are available':
+        # command   => "pkgrepo remove -s '${pkgrepo_dir}' '*'",
+        command   => "pkg refresh",
+        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        logoutput => 'on_failure',
+        notify    => Exec['puppet_agent remove existing repo'],
+      }
+
       exec { 'puppet_agent remove existing repo':
-        command   => "pkgrepo remove -s '${pkgrepo_dir}' '*'",
+        command   => "rm -rf '${pkgrepo_dir}'/'*'",
         path      => '/bin:/usr/bin:/sbin:/usr/sbin',
         onlyif    => "test -f ${pkgrepo_dir}/pkg5.repository",
         logoutput => 'on_failure',
         notify    => Exec['puppet_agent create repo'],
+        require   => Exec['puppet_agent ensure pkg publishers are available']
       }
 
       exec { 'puppet_agent create repo':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,9 @@ class puppet_agent::params {
   case $::osfamily {
     'RedHat', 'Amazon', 'Debian', 'Suse', 'Solaris', 'Darwin', 'AIX': {
       $package_name = 'puppet-agent'
-      $service_names = ['puppet', 'mcollective']
+      if !($::osfamily == 'Solaris' and $::operatingsystemmajrelease == '11') {
+        $service_names = ['puppet', 'mcollective']
+      }
 
       $confdir = '/etc/puppetlabs/puppet'
       $mco_dir = '/etc/puppetlabs/mcollective'

--- a/manifests/service/solaris.pp
+++ b/manifests/service/solaris.pp
@@ -14,13 +14,13 @@ class puppet_agent::service::solaris {
       ensure => stopped,
     }
   } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
-    file { "/tmp/solaris_start_puppet.sh":
+    file { '/tmp/solaris_start_puppet.sh':
       ensure  => file,
       content => template('puppet_agent/solaris_start_puppet.sh.erb'),
-      mode    => '755',
+      mode    => '0755',
     } ->
     exec { 'solaris_start_puppet.sh':
-      command => "/tmp/solaris_start_puppet.sh &",
+      command => '/tmp/solaris_start_puppet.sh &',
       path    => '/usr/bin:/bin:/usr/sbin',
     }
     file { ['/var/opt/lib', '/var/opt/lib/pe-puppet', '/var/opt/lib/pe-puppet/state']:

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -13,7 +13,6 @@ describe 'puppet_agent' do
           elsif os =~ /solaris/
             facts.merge({
               :is_pe => true,
-              :operatingsystemmajrelease => facts[:operatingsystemrelease].split('.')[1],
             })
           else
             facts
@@ -51,12 +50,26 @@ describe 'puppet_agent' do
                 it { is_expected.to contain_class('puppet_agent::service') }
 
                 if params[:service_names].nil?
-                  it { is_expected.to contain_service('puppet') }
-                  it { is_expected.to contain_service('mcollective') }
+                  if (facts[:osfamily] == 'Solaris' and facts[:operatingsystemmajrelease] == '11') || facts[:osfamily] == 'Sles'
+                    it { is_expected.to_not contain_service('puppet') }
+                    it { is_expected.to_not contain_service('mcollective') }
+                  else
+                    it { is_expected.to contain_service('puppet') }
+                    it { is_expected.to contain_service('mcollective') }
+                  end
                 else
                   it { is_expected.to_not contain_service('puppet') }
                   it { is_expected.to_not contain_service('mcollective') }
                 end
+
+                #if params[:service_names].nil? && ((facts[:osfamily] != 'Solaris' && facts[:operatingsystemmajrelease] != '11') && (facts[:osfamily] != 'Sles'))
+                #  it { is_expected.to contain_service('puppet') }
+                #  it { is_expected.to contain_service('mcollective') }
+                #else
+                #  it { is_expected.to_not contain_service('puppet') }
+                #  it { is_expected.to_not contain_service('mcollective') }
+                #end
+
                 it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
               else
                 it { is_expected.to_not contain_service('puppet') }


### PR DESCRIPTION
I'm right in the middle of a 2015.3 upgrade and needed this functionality out the door.  Additionally, I needed to enable [upgrades of 3.7.0 clients](https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/81)  so I included  that pull request as well.  I've tested on 11.2/11.3 i386 locally on my workstation.  I plan to use this to upgrade 11.2/11.3 sparc as well.  Take it or leave it as you will, just thought I'd share.
