### PR TITLE
Force puppetlabs.com publisher to use our newly minted file repo

### DIFF
--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -94,6 +94,14 @@ class puppet_agent::osfamily::solaris(
         logoutput => 'on_failure',
       }
 
+      # Configure publisher and set origin to our newly minted repo
+      exec { 'puppet_agent configure publisher':
+        command   => "pkg set-publisher -G '*' -g file://${pkgrepo_dir} puppetlabs.com",
+        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        require   => Exec['puppet_agent copy packages'],
+        logoutput => 'on_failure',
+      }
+
     }
     default: {
       fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")


### PR DESCRIPTION
If the pkg publisher for puppetlabs.com is missing then the install
will fail.  This sets the publisher and points it at the newly
created repository.
